### PR TITLE
closed cap object and destroyed all windows

### DIFF
--- a/chapter1.py
+++ b/chapter1.py
@@ -37,3 +37,6 @@ while True:
     cv2.imshow('Video', img)
     if cv2.waitKey(1) & 0xFF == ord('q'):
         break
+# release cap object and destroy all windows
+cap.release() 
+cv2.destroyAllWindows() 


### PR DESCRIPTION
Always close open object and destroy cv windows. This may lead to a locked camera or windows on the system.